### PR TITLE
Bump build number

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 894e2ec0a30c41c87fa583222a49e9f37b101365a11d2502cc305113e8a082b0
 
 build:
-  number: 2
+  number: 3
   skip:
     - pypy
     - win


### PR DESCRIPTION

* [x] Bumped the build number (if the version is unchanged)

The python 3.13 PR bumped the number in parallel to the CLI build, and I didn't realize. Sorry about the noise.